### PR TITLE
Allow to display firebase storage image resources

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,9 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   optimizeFonts: true,
-}
+  images: {
+    domains: ["firebasestorage.googleapis.com"],
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;


### PR DESCRIPTION
## About

firebase storage の画像を表示するため、next.config.js に firebase domain を許可するような設定を追加

## QA


- firebase sotrage リソースの画像を正常に表示できていることを確認

![image](https://user-images.githubusercontent.com/23535127/180458104-f20d99b5-a416-479c-8db5-e1b8a9e976c9.png)
